### PR TITLE
Fix method name for loading text domain & remove unnecessary __call() #33

### DIFF
--- a/edd-activecampaign.php
+++ b/edd-activecampaign.php
@@ -146,7 +146,7 @@ final class EDD_ActiveCampaign {
 	 *
 	 * @param string $key Variable name.
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	public function __isset( $key ) {
 		return isset( $this->data[ $key ] );
@@ -198,23 +198,6 @@ final class EDD_ActiveCampaign {
 	}
 
 	/**
-	 * Magic method to prevent notices and errors from invalid method calls.
-	 *
-	 * @access public
-	 * @since  1.1
-	 *
-	 * @param string $name
-	 * @param array  $args
-	 *
-	 * @return void
-	 */
-	public function __call( $name = '', $args = array() ) {
-		unset( $name, $args );
-
-		return null;
-	}
-
-	/**
 	 * Reset the instance of the class.
 	 *
 	 * @access public
@@ -238,7 +221,7 @@ final class EDD_ActiveCampaign {
 	public function init() {
 		do_action( 'edd_activecampaign_before_init' );
 
-		$this->load_textdomain();
+		$this->load_plugin_textdomain();
 
 		do_action( 'edd_activecampaign_after_init' );
 	}


### PR DESCRIPTION
Closes #33

- Fixes the method name for loading the text domain.
- Removes the `__call()` method. This method existing was why the plugin wasn't throwing a fatal error for using a method name that doesn't exist. Having that there actually _caused_ problems. A feature wasn't working and nobody noticed.