### PR TITLE
Move subscription logic to edd_after_payment_actions #32

### DIFF
--- a/edd-activecampaign.php
+++ b/edd-activecampaign.php
@@ -645,16 +645,12 @@ final class EDD_ActiveCampaign {
 		$list_ids = $this->build_product_subscription_lists( $payment );
 
 		if ( empty( $list_ids ) ) {
-			if ( function_exists( 'edd_debug_log' ) ) {
-				edd_debug_log( 'ActiveCampaign Debug - List Check. No Download list ID predefined, attempting to load site default.' );
-			}
+			edd_debug_log( 'ActiveCampaign Debug - List Check. No Download list ID predefined, attempting to load site default.' );
 
 			// No Download list set so return global list ID
 			$list_id = edd_get_option( 'eddactivecampaign_list', false );
 			if ( ! $list_id ) {
-				if ( function_exists( 'edd_debug_log' ) ) {
-					edd_debug_log( 'ActiveCampaign Debug - List Check. No global site list ID defined, exiting.' );
-				}
+				edd_debug_log( 'ActiveCampaign Debug - List Check. No global site list ID defined, exiting.' );
 				return false;
 			}
 


### PR DESCRIPTION
Issue: #32 

- Introduces new `maybe_subscribe_customer()` method which hooks into `edd_after_payment_actions()`. See issue for reasoning: https://github.com/easydigitaldownloads/edd-activecampaign/issues/32#issuecomment-839727158 Logic in this function is mostly the same as before, except it loops over all downloads attached to the order. List logic has been split into a new method `build_product_subscription_lists()`
- Deprecated `completed_download_purchase_signup()` method.

@robincornett please test in EDD 2.x.  @LisaCee please test in EDD 3.0. If either of you don't have a developer account you can request one here: https://developers.activecampaign.com/page/developer-sandbox-accounts Approval usually comes within 10 minutes.