### PR TITLE
#37 Check for property "success"

### DIFF
--- a/edd-activecampaign.php
+++ b/edd-activecampaign.php
@@ -550,9 +550,7 @@ final class EDD_ActiveCampaign {
 
 		$lists = $ac->api( 'list/list', array( 'ids' => 'all' ) );
 
-		// var_dump($lists);
-
-		if ( (int) $lists->success ) {
+		if ( $lists->success && (int) $lists->success ) {
 			// We need to cast the object to an array because ActiveCampaign returns invalid JSON.
 			$lists = (array) $lists;
 

--- a/edd-activecampaign.php
+++ b/edd-activecampaign.php
@@ -550,7 +550,7 @@ final class EDD_ActiveCampaign {
 
 		$lists = $ac->api( 'list/list', array( 'ids' => 'all' ) );
 
-		if ( $lists->success && (int) $lists->success ) {
+		if ( isset( $lists->success ) && (int) $lists->success ) {
 			// We need to cast the object to an array because ActiveCampaign returns invalid JSON.
 			$lists = (array) $lists;
 


### PR DESCRIPTION
Issue: #37 

- Check if list retrieval has success status before further checking to avoid warnings.

I'm not sure how to test this, as it seems to be a pretty specific case.